### PR TITLE
Update: BricksSync test and WPGraphQL version bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Grow Therapy WordPress site",
     "type": "project",
     "require": {
-        "wpackagist-plugin/wp-graphql": "^1.15"
+        "wpackagist-plugin/wp-graphql": "^2.3.3"
     },
     "extra": {
         "installer-paths": {

--- a/wp-content/themes/growtherapy/brickssync-json/bricks-builder-settings.json
+++ b/wp-content/themes/growtherapy/brickssync-json/bricks-builder-settings.json
@@ -15423,7 +15423,7 @@
         "acss_import_hidden-accessible",
         "acss_import_clickable-parent"
     ],
-    "bricks_global_classes_timestamp": "1755122264",
+    "bricks_global_classes_timestamp": "1755128919",
     "bricks_global_classes_trash": [],
     "bricks_global_classes_user": "2",
     "bricks_global_settings": {
@@ -15484,31 +15484,22 @@
                 "conditions": {
                     "conditions": [
                         {
-                            "id": "mgwzao",
+                            "id": "ghudpl",
                             "main": "any"
                         }
                     ]
                 },
                 "typography": {
-                    "typographyHtml:mobile_portrait": "var(--root-font-size)",
-                    "typographyBody:mobile_portrait": {
-                        "font-family": "custom_font_14"
-                    },
+                    "typographyHtml": "var(--root-font-size)",
                     "typographyBody": {
                         "font-family": "custom_font_14"
                     },
                     "typographyHeadings": {
-                        "color": {
-                            "hex": "#ff0000"
-                        }
+                        "font-family": "custom_font_14"
                     }
                 },
                 "container": {
-                    "width:mobile_portrait": "var(--content-width)",
-                    "padding": {
-                        "top": "var(--section-space-m)",
-                        "bottom": "var(--section-space-m)"
-                    }
+                    "width": "var(--content-width)"
                 },
                 "code": {
                     "prettify": "tomorrow-night"


### PR DESCRIPTION
Related task: [[link to clickup - GT-1235](https://app.clickup.com/t/30963010/GT-1235)]

# Fixes, Changes, Additions, Removals (What)
- Updated Bricks global theme style requirements for ACSS to be "desktop-first" (previously we were set up as mobile-first so the customizations got applied there).  Also testing small change to see how it affects Kinsta dev env.
- Bump WPGraphQL version from 1.15 to 2.3.3