### PR TITLE
Feature: Grow Plugin for Dynamic Tags for Bricks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ wp-content/plugins/*
 !wp-content/plugins/gravityforms/
 !wp-content/plugins/gravityformssurvey/
 !wp-content/plugins/gravityformswebhooks/
+!wp-content/plugins/grow-dynamic-tags-for-bricks/
 !wp-content/plugins/grow-global-data-tags-for-bricks/
 !wp-content/plugins/happyfiles-pro/
 !wp-content/plugins/perfmatters/

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/grow-bricks-dynamic-tags.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/grow-bricks-dynamic-tags.php
@@ -4,31 +4,37 @@
  * Description: Custom Bricks dynamic tags: {gt_ctx:...} (host page context) and {gt_field:...} (meta fetcher with nested tag rendering & formatters).
  * Version:     1.2.1
  * Author:      Grow
+ * Requires PHP: 7.4
  */
 
-if (!defined('ABSPATH')) { exit; }
+declare(strict_types=1);
 
-// Boot after theme so Bricks is available (defines constants/functions).
-add_action('after_setup_theme', static function () {
-  // Bricks present?
-  $bricks_loaded = defined('BRICKS_VERSION') || function_exists('bricks_render_dynamic_data') || did_action('bricks/init');
-  if (!$bricks_loaded) {
-    add_action('admin_notices', static function () {
-      if (!current_user_can('activate_plugins')) return;
-      echo '<div class="notice notice-error"><p><strong>Grow • Bricks Dynamic Tags</strong> requires the Bricks theme to be active.</p></div>';
-    });
-    return;
-  }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-  // Includes (no composer/autoload)
-  $base = __DIR__ . '/src';
-  require_once $base . '/plugin.php';
-  require_once $base . '/rendering/content-renderer.php';
-  require_once $base . '/rendering/finalizer.php';
-  require_once $base . '/tags/gt-field-tag.php';
-  require_once $base . '/tags/gt-ctx-tag.php';
-  require_once $base . '/support/parser.php';
-  require_once $base . '/support/context.php';
+// Boot after theme so Bricks is available
+add_action('after_setup_theme', static function (): void {
+    // Check if Bricks is available
+    if (!defined('BRICKS_VERSION') && !function_exists('bricks_render_dynamic_data') && !did_action('bricks/init')) {
+        add_action('admin_notices', static function (): void {
+            if (!current_user_can('activate_plugins')) {
+                return;
+            }
+            echo '<div class="notice notice-error"><p><strong>Grow • Bricks Dynamic Tags</strong> requires the Bricks theme to be active.</p></div>';
+        });
+        return;
+    }
 
-  \Grow\BricksTags\Plugin::init();
+    // Autoload classes
+    $base = __DIR__ . '/src';
+    require_once $base . '/plugin.php';
+    require_once $base . '/rendering/content-renderer.php';
+    require_once $base . '/rendering/finalizer.php';
+    require_once $base . '/tags/gt-field-tag.php';
+    require_once $base . '/tags/gt-ctx-tag.php';
+    require_once $base . '/support/parser.php';
+    require_once $base . '/support/context.php';
+
+    \Grow\BricksTags\Plugin::init();
 });

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/grow-bricks-dynamic-tags.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/grow-bricks-dynamic-tags.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Grow • Bricks Dynamic Tags
+ * Description: Custom Bricks dynamic tags: {gt_ctx:...} (host page context) and {gt_field:...} (meta fetcher with nested tag rendering & formatters).
+ * Version:     1.2.1
+ * Author:      Grow
+ */
+
+if (!defined('ABSPATH')) { exit; }
+
+// Boot after theme so Bricks is available (defines constants/functions).
+add_action('after_setup_theme', static function () {
+  // Bricks present?
+  $bricks_loaded = defined('BRICKS_VERSION') || function_exists('bricks_render_dynamic_data') || did_action('bricks/init');
+  if (!$bricks_loaded) {
+    add_action('admin_notices', static function () {
+      if (!current_user_can('activate_plugins')) return;
+      echo '<div class="notice notice-error"><p><strong>Grow • Bricks Dynamic Tags</strong> requires the Bricks theme to be active.</p></div>';
+    });
+    return;
+  }
+
+  // Includes (no composer/autoload)
+  $base = __DIR__ . '/src';
+  require_once $base . '/plugin.php';
+  require_once $base . '/rendering/content-renderer.php';
+  require_once $base . '/rendering/finalizer.php';
+  require_once $base . '/tags/gt-field-tag.php';
+  require_once $base . '/tags/gt-ctx-tag.php';
+  require_once $base . '/support/parser.php';
+  require_once $base . '/support/context.php';
+
+  \Grow\BricksTags\Plugin::init();
+});

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
@@ -1,81 +1,156 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags;
 
 use Grow\BricksTags\Rendering\ContentRenderer;
 use Grow\BricksTags\Tags\GtCtxTag;
 use Grow\BricksTags\Tags\GtFieldTag;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class Plugin {
-  // Public tag slugs
-  public const TAG_FIELD = 'gt_field';
-  public const TAG_CTX   = 'gt_ctx';
+/**
+ * Main plugin class for Grow Bricks Dynamic Tags
+ * 
+ * Provides two dynamic tags:
+ * - {gt_ctx:...} for host page context resolution
+ * - {gt_field:...} for meta data fetching with nested tag support
+ */
+final class Plugin
+{
+    // Public tag slugs
+    public const TAG_FIELD = 'gt_field';
+    public const TAG_CTX = 'gt_ctx';
 
-  // Recursion guard (global)
-  private static int $depth = 0;
-  private const MAX_DEPTH = 8;
+    // Recursion protection
+    private static int $depth = 0;
+    private const MAX_DEPTH = 8;
 
-  // Optional diagnostics
-  private const DEBUG = false;
+    // Performance optimization: cache compiled regex patterns
+    private static ?string $tagPattern = null;
 
-  public static function init(): void {
-    // 1) Register tags for Bricks UI/parser (register both bare + brace for compatibility)
-    add_filter('bricks/dynamic_tags_list', [self::class, 'registerTags']);
+    /**
+     * Initialize the plugin
+     */
+    public static function init(): void
+    {
+        // Register tags for Bricks UI
+        add_filter('bricks/dynamic_tags_list', [self::class, 'registerTags']);
 
-    // 2) Tag-level resolver (Bricks calls this for each discovered tag)
-    add_filter('bricks/dynamic_data/render_tag', [self::class, 'renderTag'], 20, 3);
+        // Tag-level resolver
+        add_filter('bricks/dynamic_data/render_tag', [self::class, 'renderTag'], 20, 3);
 
-    // 3) Early pre-pass — resolve {gt_ctx:...} BEFORE other tags
-    add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendPre'], 1, 3);
-    add_filter('bricks/frontend/render_data',       [ContentRenderer::class, 'frontendPre'], 1, 3);   // <— was 2
+        // Early pre-pass for {gt_ctx:...} tags
+        add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendPre'], 1, 3);
+        add_filter('bricks/frontend/render_data', [ContentRenderer::class, 'frontendPre'], 1, 3);
 
-    // 4) Fallback content replacer — guarantee our tags render anywhere
-    add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendFallback'], 20, 3);
-    add_filter('bricks/frontend/render_data',       [ContentRenderer::class, 'frontendFallback'], 20, 3); // <— was 2
-  }
-
-  /** Show tags in the Bricks picker */
-  public static function registerTags(array $tags): array {
-    // Dual registration (brace + bare)
-    $tags[] = ['name' => self::TAG_FIELD,              'label' => 'GT • Meta (parse inner tags)', 'group' => 'Grow'];
-    $tags[] = ['name' => '{' . self::TAG_FIELD . '}',  'label' => 'GT • Meta (parse inner tags)', 'group' => 'Grow'];
-    $tags[] = ['name' => self::TAG_CTX,                'label' => 'GT • Host Page Context',        'group' => 'Grow'];
-    $tags[] = ['name' => '{' . self::TAG_CTX . '}',    'label' => 'GT • Host Page Context',        'group' => 'Grow'];
-    return $tags;
-  }
-
-  /** Dispatch Bricks dynamic tag → our implementation */
-  public static function renderTag($tag, $post, string $context = 'text') {
-    if (!is_string($tag)) return $tag;
-    if (!self::enter()) return $tag;
-    try {
-      $clean = trim($tag, '{}');
-
-      if (strpos($clean, self::TAG_FIELD . ':') === 0) {
-        return GtFieldTag::render(substr($clean, strlen(self::TAG_FIELD . ':')), $post, $context);
-      }
-      if (strpos($clean, self::TAG_CTX . ':') === 0) {
-        return GtCtxTag::render(substr($clean, strlen(self::TAG_CTX . ':')), $post, $context);
-      }
-      return $tag;
-    } finally {
-      self::leave();
+        // Fallback content replacer
+        add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendFallback'], 20, 3);
+        add_filter('bricks/frontend/render_data', [ContentRenderer::class, 'frontendFallback'], 20, 3);
     }
-  }
 
-  /** Recursion guard enter */
-  public static function enter(): bool {
-    if (self::$depth >= self::MAX_DEPTH) {
-      if (self::DEBUG) error_log('[GT Tags] depth cap reached; aborting render step');
-      return false;
+    /**
+     * Register tags in the Bricks picker
+     */
+    public static function registerTags(array $tags): array
+    {
+        $tags[] = [
+            'name' => self::TAG_FIELD,
+            'label' => 'GT • Meta (parse inner tags)',
+            'group' => 'Grow'
+        ];
+        $tags[] = [
+            'name' => '{' . self::TAG_FIELD . '}',
+            'label' => 'GT • Meta (parse inner tags)',
+            'group' => 'Grow'
+        ];
+        $tags[] = [
+            'name' => self::TAG_CTX,
+            'label' => 'GT • Host Page Context',
+            'group' => 'Grow'
+        ];
+        $tags[] = [
+            'name' => '{' . self::TAG_CTX . '}',
+            'label' => 'GT • Host Page Context',
+            'group' => 'Grow'
+        ];
+
+        return $tags;
     }
-    self::$depth++;
-    return true;
-  }
 
-  /** Recursion guard leave */
-  public static function leave(): void {
-    if (self::$depth > 0) self::$depth--;
-  }
+    /**
+     * Dispatch Bricks dynamic tag to our implementation
+     */
+    public static function renderTag($tag, $post, string $context = 'text')
+    {
+        if (!is_string($tag)) {
+            return $tag;
+        }
+
+        if (!self::enter()) {
+            return $tag;
+        }
+
+        try {
+            $clean = trim($tag, '{}');
+
+            if (str_starts_with($clean, self::TAG_FIELD . ':')) {
+                return GtFieldTag::render(
+                    substr($clean, strlen(self::TAG_FIELD . ':')),
+                    $post,
+                    $context
+                );
+            }
+
+            if (str_starts_with($clean, self::TAG_CTX . ':')) {
+                return GtCtxTag::render(
+                    substr($clean, strlen(self::TAG_CTX . ':')),
+                    $post,
+                    $context
+                );
+            }
+
+            return $tag;
+        } finally {
+            self::leave();
+        }
+    }
+
+    /**
+     * Get compiled regex pattern for tag matching
+     */
+    public static function getTagPattern(): string
+    {
+        if (self::$tagPattern === null) {
+            self::$tagPattern = '/{(gt_(?:field|ctx):[^}]+)}/';
+        }
+
+        return self::$tagPattern;
+    }
+
+    /**
+     * Recursion guard enter
+     */
+    public static function enter(): bool
+    {
+        if (self::$depth >= self::MAX_DEPTH) {
+            return false;
+        }
+
+        self::$depth++;
+        return true;
+    }
+
+    /**
+     * Recursion guard leave
+     */
+    public static function leave(): void
+    {
+        if (self::$depth > 0) {
+            self::$depth--;
+        }
+    }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
@@ -23,7 +23,9 @@ final class Plugin
 {
     // Public tag slugs
     public const TAG_FIELD = 'gt_field';
+    public const TAG_FIELD_PREFIX = 'gt_field:';
     public const TAG_CTX = 'gt_ctx';
+    public const TAG_CTX_PREFIX = 'gt_ctx:';
 
     // Recursion protection
     private static int $depth = 0;
@@ -97,17 +99,17 @@ final class Plugin
         try {
             $clean = trim($tag, '{}');
 
-            if (str_starts_with($clean, self::TAG_FIELD . ':')) {
+            if (str_starts_with($clean, self::TAG_FIELD_PREFIX)) {
                 return GtFieldTag::render(
-                    substr($clean, strlen(self::TAG_FIELD . ':')),
+                    substr($clean, strlen(self::TAG_FIELD_PREFIX)),
                     $post,
                     $context
                 );
             }
 
-            if (str_starts_with($clean, self::TAG_CTX . ':')) {
+            if (str_starts_with($clean, self::TAG_CTX_PREFIX)) {
                 return GtCtxTag::render(
-                    substr($clean, strlen(self::TAG_CTX . ':')),
+                    substr($clean, strlen(self::TAG_CTX_PREFIX)),
                     $post,
                     $context
                 );

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/plugin.php
@@ -1,0 +1,81 @@
+<?php
+namespace Grow\BricksTags;
+
+use Grow\BricksTags\Rendering\ContentRenderer;
+use Grow\BricksTags\Tags\GtCtxTag;
+use Grow\BricksTags\Tags\GtFieldTag;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class Plugin {
+  // Public tag slugs
+  public const TAG_FIELD = 'gt_field';
+  public const TAG_CTX   = 'gt_ctx';
+
+  // Recursion guard (global)
+  private static int $depth = 0;
+  private const MAX_DEPTH = 8;
+
+  // Optional diagnostics
+  private const DEBUG = false;
+
+  public static function init(): void {
+    // 1) Register tags for Bricks UI/parser (register both bare + brace for compatibility)
+    add_filter('bricks/dynamic_tags_list', [self::class, 'registerTags']);
+
+    // 2) Tag-level resolver (Bricks calls this for each discovered tag)
+    add_filter('bricks/dynamic_data/render_tag', [self::class, 'renderTag'], 20, 3);
+
+    // 3) Early pre-pass — resolve {gt_ctx:...} BEFORE other tags
+    add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendPre'], 1, 3);
+    add_filter('bricks/frontend/render_data',       [ContentRenderer::class, 'frontendPre'], 1, 3);   // <— was 2
+
+    // 4) Fallback content replacer — guarantee our tags render anywhere
+    add_filter('bricks/dynamic_data/render_content', [ContentRenderer::class, 'backendFallback'], 20, 3);
+    add_filter('bricks/frontend/render_data',       [ContentRenderer::class, 'frontendFallback'], 20, 3); // <— was 2
+  }
+
+  /** Show tags in the Bricks picker */
+  public static function registerTags(array $tags): array {
+    // Dual registration (brace + bare)
+    $tags[] = ['name' => self::TAG_FIELD,              'label' => 'GT • Meta (parse inner tags)', 'group' => 'Grow'];
+    $tags[] = ['name' => '{' . self::TAG_FIELD . '}',  'label' => 'GT • Meta (parse inner tags)', 'group' => 'Grow'];
+    $tags[] = ['name' => self::TAG_CTX,                'label' => 'GT • Host Page Context',        'group' => 'Grow'];
+    $tags[] = ['name' => '{' . self::TAG_CTX . '}',    'label' => 'GT • Host Page Context',        'group' => 'Grow'];
+    return $tags;
+  }
+
+  /** Dispatch Bricks dynamic tag → our implementation */
+  public static function renderTag($tag, $post, string $context = 'text') {
+    if (!is_string($tag)) return $tag;
+    if (!self::enter()) return $tag;
+    try {
+      $clean = trim($tag, '{}');
+
+      if (strpos($clean, self::TAG_FIELD . ':') === 0) {
+        return GtFieldTag::render(substr($clean, strlen(self::TAG_FIELD . ':')), $post, $context);
+      }
+      if (strpos($clean, self::TAG_CTX . ':') === 0) {
+        return GtCtxTag::render(substr($clean, strlen(self::TAG_CTX . ':')), $post, $context);
+      }
+      return $tag;
+    } finally {
+      self::leave();
+    }
+  }
+
+  /** Recursion guard enter */
+  public static function enter(): bool {
+    if (self::$depth >= self::MAX_DEPTH) {
+      if (self::DEBUG) error_log('[GT Tags] depth cap reached; aborting render step');
+      return false;
+    }
+    self::$depth++;
+    return true;
+  }
+
+  /** Recursion guard leave */
+  public static function leave(): void {
+    if (self::$depth > 0) self::$depth--;
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
@@ -1,0 +1,83 @@
+<?php
+namespace Grow\BricksTags\Rendering;
+
+use Grow\BricksTags\Plugin;
+use Grow\BricksTags\Tags\GtCtxTag;
+use Grow\BricksTags\Tags\GtFieldTag;
+use Grow\BricksTags\Support\Parser;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class ContentRenderer {
+  // Prevent repeated pre-pass on the same render pipeline
+  private static bool $ctxPassActive = false;
+
+  /** Builder: early pre-pass — resolve {gt_ctx:...} first */
+  public static function backendPre($content, $post, string $context = 'text') {
+    if (!is_string($content) || strpos($content, '{gt_ctx:') === false) return $content;
+    if (self::$ctxPassActive) return $content;
+    if (!Plugin::enter()) return $content;
+    self::$ctxPassActive = true;
+    try {
+      return Parser::resolveGtCtxWithinString($content, $context);
+    } finally {
+      self::$ctxPassActive = false;
+      Plugin::leave();
+    }
+  }
+
+  /** Frontend: early pre-pass — resolve {gt_ctx:...} first (signature = ($content, $post, $context)) */
+  public static function frontendPre($content, $post, string $context = 'text') {
+    if (!is_string($content) || strpos($content, '{gt_ctx:') === false) return $content;
+    if (self::$ctxPassActive) return $content;
+    if (!Plugin::enter()) return $content;
+    self::$ctxPassActive = true;
+    try {
+      return Parser::resolveGtCtxWithinString($content, $context);
+    } finally {
+      self::$ctxPassActive = false;
+      Plugin::leave();
+    }
+  }
+
+  /** Builder: fallback replacer — render any remaining {gt_field:...}/{gt_ctx:...} inline */
+  public static function backendFallback($content, $post, string $context = 'text') {
+    return self::replaceAllOurTags($content, $post, $context);
+  }
+
+  /** Frontend: fallback replacer (signature = ($content, $post, $context)) */
+  public static function frontendFallback($content, $post, string $context = 'text') {
+    return self::replaceAllOurTags($content, $post, $context);
+  }
+
+  private static function replaceAllOurTags($content, $post, string $context) {
+    if (!is_string($content) || strpos($content, '{gt_') === false) return $content;
+    if (!Plugin::enter()) return $content;
+    try {
+      if (!preg_match_all('/{(gt_(?:field|ctx):[^}]+)}/', $content, $matches, PREG_SET_ORDER)) {
+        return $content;
+      }
+      foreach ($matches as $m) {
+        $whole = $m[0];   // with braces
+        $inner = $m[1];   // without braces
+
+        if (strpos($inner, Plugin::TAG_FIELD . ':') === 0) {
+          $replacement = GtFieldTag::render(substr($inner, strlen(Plugin::TAG_FIELD . ':')), $post, $context);
+        } elseif (strpos($inner, Plugin::TAG_CTX . ':') === 0) {
+          $replacement = GtCtxTag::render(substr($inner, strlen(Plugin::TAG_CTX . ':')), $post, $context);
+        } else {
+          $replacement = $whole;
+        }
+
+        // SAFE literal single replacement: avoid preg replacement so $ and \ aren't treated as backrefs/escapes
+        $pos = strpos($content, $whole);
+        if ($pos !== false) {
+          $content = substr_replace($content, (string)$replacement, $pos, strlen($whole));
+        }
+      }
+      return $content;
+    } finally {
+      Plugin::leave();
+    }
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags\Rendering;
 
 use Grow\BricksTags\Plugin;
@@ -6,78 +9,150 @@ use Grow\BricksTags\Tags\GtCtxTag;
 use Grow\BricksTags\Tags\GtFieldTag;
 use Grow\BricksTags\Support\Parser;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class ContentRenderer {
-  // Prevent repeated pre-pass on the same render pipeline
-  private static bool $ctxPassActive = false;
+/**
+ * Content renderer for processing dynamic tags in Bricks content
+ * 
+ * Handles both backend (builder) and frontend rendering with
+ * optimized performance and proper recursion protection.
+ */
+final class ContentRenderer
+{
+    // Prevent repeated pre-pass on the same render pipeline
+    private static bool $ctxPassActive = false;
 
-  /** Builder: early pre-pass — resolve {gt_ctx:...} first */
-  public static function backendPre($content, $post, string $context = 'text') {
-    if (!is_string($content) || strpos($content, '{gt_ctx:') === false) return $content;
-    if (self::$ctxPassActive) return $content;
-    if (!Plugin::enter()) return $content;
-    self::$ctxPassActive = true;
-    try {
-      return Parser::resolveGtCtxWithinString($content, $context);
-    } finally {
-      self::$ctxPassActive = false;
-      Plugin::leave();
-    }
-  }
-
-  /** Frontend: early pre-pass — resolve {gt_ctx:...} first (signature = ($content, $post, $context)) */
-  public static function frontendPre($content, $post, string $context = 'text') {
-    if (!is_string($content) || strpos($content, '{gt_ctx:') === false) return $content;
-    if (self::$ctxPassActive) return $content;
-    if (!Plugin::enter()) return $content;
-    self::$ctxPassActive = true;
-    try {
-      return Parser::resolveGtCtxWithinString($content, $context);
-    } finally {
-      self::$ctxPassActive = false;
-      Plugin::leave();
-    }
-  }
-
-  /** Builder: fallback replacer — render any remaining {gt_field:...}/{gt_ctx:...} inline */
-  public static function backendFallback($content, $post, string $context = 'text') {
-    return self::replaceAllOurTags($content, $post, $context);
-  }
-
-  /** Frontend: fallback replacer (signature = ($content, $post, $context)) */
-  public static function frontendFallback($content, $post, string $context = 'text') {
-    return self::replaceAllOurTags($content, $post, $context);
-  }
-
-  private static function replaceAllOurTags($content, $post, string $context) {
-    if (!is_string($content) || strpos($content, '{gt_') === false) return $content;
-    if (!Plugin::enter()) return $content;
-    try {
-      if (!preg_match_all('/{(gt_(?:field|ctx):[^}]+)}/', $content, $matches, PREG_SET_ORDER)) {
-        return $content;
-      }
-      foreach ($matches as $m) {
-        $whole = $m[0];   // with braces
-        $inner = $m[1];   // without braces
-
-        if (strpos($inner, Plugin::TAG_FIELD . ':') === 0) {
-          $replacement = GtFieldTag::render(substr($inner, strlen(Plugin::TAG_FIELD . ':')), $post, $context);
-        } elseif (strpos($inner, Plugin::TAG_CTX . ':') === 0) {
-          $replacement = GtCtxTag::render(substr($inner, strlen(Plugin::TAG_CTX . ':')), $post, $context);
-        } else {
-          $replacement = $whole;
+    /**
+     * Backend pre-pass: resolve {gt_ctx:...} tags first
+     */
+    public static function backendPre($content, $post, string $context = 'text')
+    {
+        if (!is_string($content) || strpos($content, '{gt_ctx:') === false) {
+            return $content;
         }
 
-        // SAFE literal single replacement: avoid preg replacement so $ and \ aren't treated as backrefs/escapes
-        $pos = strpos($content, $whole);
-        if ($pos !== false) {
-          $content = substr_replace($content, (string)$replacement, $pos, strlen($whole));
+        if (self::$ctxPassActive) {
+            return $content;
         }
-      }
-      return $content;
-    } finally {
-      Plugin::leave();
+
+        if (!Plugin::enter()) {
+            return $content;
+        }
+
+        self::$ctxPassActive = true;
+        try {
+            return Parser::resolveGtCtxWithinString($content, $context);
+        } finally {
+            self::$ctxPassActive = false;
+            Plugin::leave();
+        }
     }
-  }
+
+    /**
+     * Frontend pre-pass: resolve {gt_ctx:...} tags first
+     */
+    public static function frontendPre($content, $post, string $context = 'text')
+    {
+        if (!is_string($content) || strpos($content, '{gt_ctx:') === false) {
+            return $content;
+        }
+
+        if (self::$ctxPassActive) {
+            return $content;
+        }
+
+        if (!Plugin::enter()) {
+            return $content;
+        }
+
+        self::$ctxPassActive = true;
+        try {
+            return Parser::resolveGtCtxWithinString($content, $context);
+        } finally {
+            self::$ctxPassActive = false;
+            Plugin::leave();
+        }
+    }
+
+    /**
+     * Backend fallback: render any remaining tags inline
+     */
+    public static function backendFallback($content, $post, string $context = 'text')
+    {
+        return self::replaceAllOurTags($content, $post, $context);
+    }
+
+    /**
+     * Frontend fallback: render any remaining tags inline
+     */
+    public static function frontendFallback($content, $post, string $context = 'text')
+    {
+        return self::replaceAllOurTags($content, $post, $context);
+    }
+
+    /**
+     * Replace all our dynamic tags in the content
+     */
+    private static function replaceAllOurTags($content, $post, string $context)
+    {
+        if (!is_string($content) || strpos($content, '{gt_') === false) {
+            return $content;
+        }
+
+        if (!Plugin::enter()) {
+            return $content;
+        }
+
+        try {
+            // Use the cached regex pattern from Plugin class
+            $pattern = Plugin::getTagPattern();
+            
+            if (!preg_match_all($pattern, $content, $matches, PREG_SET_ORDER)) {
+                return $content;
+            }
+
+            foreach ($matches as $match) {
+                $whole = $match[0];   // with braces
+                $inner = $match[1];   // without braces
+
+                $replacement = self::renderTag($inner, $post, $context);
+                
+                // Safe literal replacement to avoid regex backreference issues
+                $pos = strpos($content, $whole);
+                if ($pos !== false) {
+                    $content = substr_replace($content, (string) $replacement, $pos, strlen($whole));
+                }
+            }
+
+            return $content;
+        } finally {
+            Plugin::leave();
+        }
+    }
+
+    /**
+     * Render a single tag based on its type
+     */
+    private static function renderTag(string $inner, $post, string $context): string
+    {
+        if (str_starts_with($inner, Plugin::TAG_FIELD . ':')) {
+            return GtFieldTag::render(
+                substr($inner, strlen(Plugin::TAG_FIELD . ':')),
+                $post,
+                $context
+            );
+        }
+
+        if (str_starts_with($inner, Plugin::TAG_CTX . ':')) {
+            return GtCtxTag::render(
+                substr($inner, strlen(Plugin::TAG_CTX . ':')),
+                $post,
+                $context
+            );
+        }
+
+        return $inner;
+    }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/content-renderer.php
@@ -137,17 +137,17 @@ final class ContentRenderer
      */
     private static function renderTag(string $inner, $post, string $context): string
     {
-        if (str_starts_with($inner, Plugin::TAG_FIELD . ':')) {
+        if (str_starts_with($inner, Plugin::TAG_FIELD_PREFIX)) {
             return GtFieldTag::render(
-                substr($inner, strlen(Plugin::TAG_FIELD . ':')),
+                substr($inner, strlen(Plugin::TAG_FIELD_PREFIX)),
                 $post,
                 $context
             );
         }
 
-        if (str_starts_with($inner, Plugin::TAG_CTX . ':')) {
+        if (str_starts_with($inner, Plugin::TAG_CTX_PREFIX)) {
             return GtCtxTag::render(
-                substr($inner, strlen(Plugin::TAG_CTX . ':')),
+                substr($inner, strlen(Plugin::TAG_CTX_PREFIX)),
                 $post,
                 $context
             );

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
@@ -1,111 +1,262 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags\Rendering;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class Finalizer {
+/**
+ * Final output processing and formatting utilities
+ * 
+ * Handles output sanitization, formatting filters, and context-specific
+ * output shaping for dynamic tag content.
+ */
+final class Finalizer
+{
+    /**
+     * Finalize output with proper sanitization and formatting
+     * 
+     * @param mixed $value The value to process
+     * @param array $flags Processing flags (raw, noescape)
+     * @param string $context The rendering context
+     * @return mixed The processed value
+     */
+    public static function finalizeOutput($value, array $flags, string $context)
+    {
+        // Handle image context arrays
+        if ($context === 'image' && is_scalar($value) && preg_match('/^\d+$/', (string) $value)) {
+            return [(int) $value];
+        }
 
-  /** final output shaping (image context arrays, sanitize unless raw/noescape, implode arrays) */
-  public static function finalizeOutput($value, array $flags, string $context) {
-    // Image context wants array of IDs
-    if ($context === 'image' && is_scalar($value) && preg_match('/^\d+$/', (string)$value)) {
-      return [ (int)$value ];
+        // Sanitize unless raw/noescape flags are set
+        if (!in_array('raw', $flags, true) && !in_array('noescape', $flags, true)) {
+            $value = self::sanitizeValue($value);
+        }
+
+        // Convert arrays to readable strings
+        if (is_array($value)) {
+            $value = implode(', ', array_map('strval', $value));
+        }
+
+        return $value;
     }
 
-    // Sanitize unless raw/noescape
-    if (!in_array('raw', $flags, true) && !in_array('noescape', $flags, true)) {
-      if (is_array($value)) {
-        $value = array_map(static function ($v) {
-          return is_string($v) ? wp_kses_post($v) : $v;
-        }, $value);
-      } elseif (is_string($value)) {
-        $value = wp_kses_post($value);
-      }
+    /**
+     * Check if a value is effectively empty
+     */
+    public static function isEffectivelyEmpty($value): bool
+    {
+        if (is_array($value)) {
+            return count($value) === 0;
+        }
+        if ($value === null) {
+            return true;
+        }
+        if (is_string($value)) {
+            return trim($value) === '';
+        }
+        return false;
     }
 
-    // Readable string if still array
-    if (is_array($value)) {
-      $value = implode(', ', array_map('strval', $value));
+    /**
+     * Apply a chain of formatting filters to a value
+     */
+    public static function applyFiltersChain($value, array $filters)
+    {
+        foreach ($filters as $filter) {
+            [$name, $arg] = $filter + [null, null];
+            $value = self::applyFilter($value, $name, $arg);
+        }
+        return $value;
     }
-    return $value;
-  }
 
-  /** empty-ness check for fallbacks */
-  public static function isEffectivelyEmpty($v): bool {
-    if (is_array($v)) return count($v) === 0;
-    if ($v === null) return true;
-    if (is_string($v)) return trim($v) === '';
-    return false;
-  }
-
-  /** value transformation filters (trim/lower/upper/join/number/date/etc.) */
-  public static function applyFiltersChain($value, array $filters) {
-    foreach ($filters as $f) {
-      [$name, $arg] = $f + [null, null];
-      switch ($name) {
-        case 'trim':
-          if (is_string($value)) $value = trim($value);
-          break;
-        case 'lower':
-          if (is_string($value)) $value = function_exists('mb_strtolower') ? mb_strtolower($value) : strtolower($value);
-          break;
-        case 'upper':
-          if (is_string($value)) $value = function_exists('mb_strtoupper') ? mb_strtoupper($value) : strtoupper($value);
-          break;
-        case 'title':
-          if (is_string($value)) {
-            $value = function_exists('mb_convert_case') ? mb_convert_case($value, MB_CASE_TITLE, 'UTF-8') : ucwords(strtolower($value));
-          }
-          break;
-        case 'ucfirst':
-          if (is_string($value) && $value !== '') {
-            $first = function_exists('mb_substr') ? mb_substr($value, 0, 1) : substr($value, 0, 1);
-            $rest  = function_exists('mb_substr') ? mb_substr($value, 1)   : substr($value, 1);
-            $value = (function_exists('mb_strtoupper') ? mb_strtoupper($first) : strtoupper($first)) . $rest;
-          }
-          break;
-        case 'strip_tags':
-          if (is_string($value)) $value = strip_tags($value);
-          break;
-        case 'nl2br':
-          if (is_string($value)) $value = nl2br($value);
-          break;
-        case 'escape_attr':
-          if (is_string($value)) $value = esc_attr($value);
-          break;
-        case 'json':
-          $value = wp_json_encode($value);
-          break;
-        case 'length':
-          if (is_array($value)) $value = count($value);
-          else $value = is_string($value) ? (function_exists('mb_strlen') ? mb_strlen($value) : strlen($value)) : 0;
-          break;
-        case 'unique':
-          if (is_array($value)) $value = array_values(array_unique($value));
-          break;
-        case 'join':
-          if (is_array($value)) {
-            $sep = isset($arg) ? (string)$arg : ', ';
-            $value = implode($sep, array_map('strval', $value));
-          }
-          break;
-        case 'number':
-          $dec = is_numeric($arg) ? (int)$arg : 0;
-          if (is_numeric($value)) $value = number_format((float)$value, $dec, '.', ',');
-          break;
-        case 'date':
-          $fmt = ($arg !== null && $arg !== '') ? (string)$arg : 'Y-m-d';
-          $ts  = null;
-          if (is_numeric($value)) {
-            $ts = (int)$value;
-          } elseif (is_string($value) && $value !== '') {
-            $try = strtotime($value);
-            if ($try !== false) $ts = $try;
-          }
-          if ($ts !== null) $value = date_i18n($fmt, $ts);
-          break;
-      }
+    /**
+     * Apply a single filter to a value
+     */
+    private static function applyFilter($value, string $name, $arg)
+    {
+        switch ($name) {
+            case 'trim':
+                return is_string($value) ? trim($value) : $value;
+                
+            case 'lower':
+                return is_string($value) ? self::mbStrToLower($value) : $value;
+                
+            case 'upper':
+                return is_string($value) ? self::mbStrToUpper($value) : $value;
+                
+            case 'title':
+                return is_string($value) ? self::mbConvertCase($value, MB_CASE_TITLE) : $value;
+                
+            case 'ucfirst':
+                return is_string($value) ? self::mbUcFirst($value) : $value;
+                
+            case 'strip_tags':
+                return is_string($value) ? strip_tags($value) : $value;
+                
+            case 'nl2br':
+                return is_string($value) ? nl2br($value) : $value;
+                
+            case 'escape_attr':
+                return is_string($value) ? esc_attr($value) : $value;
+                
+            case 'json':
+                return wp_json_encode($value);
+                
+            case 'length':
+                return self::getLength($value);
+                
+            case 'unique':
+                return is_array($value) ? array_values(array_unique($value)) : $value;
+                
+            case 'join':
+                return self::joinArray($value, $arg);
+                
+            case 'number':
+                return self::formatNumber($value, $arg);
+                
+            case 'date':
+                return self::formatDate($value, $arg);
+                
+            default:
+                return $value;
+        }
     }
-    return $value;
-  }
+
+    /**
+     * Sanitize a value using WordPress functions
+     */
+    private static function sanitizeValue($value)
+    {
+        if (is_array($value)) {
+            return array_map(static function ($v) {
+                return is_string($v) ? wp_kses_post($v) : $v;
+            }, $value);
+        }
+        
+        if (is_string($value)) {
+            return wp_kses_post($value);
+        }
+        
+        return $value;
+    }
+
+    /**
+     * Multi-byte string to lowercase with fallback
+     */
+    private static function mbStrToLower(string $value): string
+    {
+        return function_exists('mb_strtolower') ? mb_strtolower($value) : strtolower($value);
+    }
+
+    /**
+     * Multi-byte string to uppercase with fallback
+     */
+    private static function mbStrToUpper(string $value): string
+    {
+        return function_exists('mb_strtoupper') ? mb_strtoupper($value) : strtoupper($value);
+    }
+
+    /**
+     * Multi-byte case conversion with fallback
+     */
+    private static function mbConvertCase(string $value, int $mode): string
+    {
+        return function_exists('mb_convert_case') 
+            ? mb_convert_case($value, $mode, 'UTF-8') 
+            : ucwords(strtolower($value));
+    }
+
+    /**
+     * Multi-byte uppercase first with fallback
+     */
+    private static function mbUcFirst(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+        
+        $first = function_exists('mb_substr') ? mb_substr($value, 0, 1) : substr($value, 0, 1);
+        $rest = function_exists('mb_substr') ? mb_substr($value, 1) : substr($value, 1);
+        
+        $firstUpper = function_exists('mb_strtoupper') ? mb_strtoupper($first) : strtoupper($first);
+        return $firstUpper . $rest;
+    }
+
+    /**
+     * Get length of value
+     */
+    private static function getLength($value): int
+    {
+        if (is_array($value)) {
+            return count($value);
+        }
+        
+        if (is_string($value)) {
+            return function_exists('mb_strlen') ? mb_strlen($value) : strlen($value);
+        }
+        
+        return 0;
+    }
+
+    /**
+     * Join array with separator
+     */
+    private static function joinArray($value, $arg): string
+    {
+        if (!is_array($value)) {
+            return (string) $value;
+        }
+        
+        $separator = $arg !== null ? (string) $arg : ', ';
+        return implode($separator, array_map('strval', $value));
+    }
+
+    /**
+     * Format number with decimal places
+     */
+    private static function formatNumber($value, $arg): string
+    {
+        if (!is_numeric($value)) {
+            return (string) $value;
+        }
+        
+        $decimals = is_numeric($arg) ? (int) $arg : 0;
+        return number_format((float) $value, $decimals, '.', ',');
+    }
+
+    /**
+     * Format date with specified format
+     */
+    private static function formatDate($value, $arg): string
+    {
+        $format = ($arg !== null && $arg !== '') ? (string) $arg : 'Y-m-d';
+        $timestamp = self::getTimestamp($value);
+        
+        if ($timestamp === null) {
+            return (string) $value;
+        }
+        
+        return date_i18n($format, $timestamp);
+    }
+
+    /**
+     * Get timestamp from various input types
+     */
+    private static function getTimestamp($value): ?int
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+        
+        if (is_string($value) && $value !== '') {
+            $timestamp = strtotime($value);
+            return $timestamp !== false ? $timestamp : null;
+        }
+        
+        return null;
+    }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
@@ -67,7 +67,7 @@ final class Finalizer
     public static function applyFiltersChain($value, array $filters)
     {
         foreach ($filters as $filter) {
-            [$name, $arg] = $filter + [null, null];
+            [$name, $arg] = $filter + array_pad($filter, 2, null);
             $value = self::applyFilter($value, $name, $arg);
         }
         return $value;

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/rendering/finalizer.php
@@ -1,0 +1,111 @@
+<?php
+namespace Grow\BricksTags\Rendering;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class Finalizer {
+
+  /** final output shaping (image context arrays, sanitize unless raw/noescape, implode arrays) */
+  public static function finalizeOutput($value, array $flags, string $context) {
+    // Image context wants array of IDs
+    if ($context === 'image' && is_scalar($value) && preg_match('/^\d+$/', (string)$value)) {
+      return [ (int)$value ];
+    }
+
+    // Sanitize unless raw/noescape
+    if (!in_array('raw', $flags, true) && !in_array('noescape', $flags, true)) {
+      if (is_array($value)) {
+        $value = array_map(static function ($v) {
+          return is_string($v) ? wp_kses_post($v) : $v;
+        }, $value);
+      } elseif (is_string($value)) {
+        $value = wp_kses_post($value);
+      }
+    }
+
+    // Readable string if still array
+    if (is_array($value)) {
+      $value = implode(', ', array_map('strval', $value));
+    }
+    return $value;
+  }
+
+  /** empty-ness check for fallbacks */
+  public static function isEffectivelyEmpty($v): bool {
+    if (is_array($v)) return count($v) === 0;
+    if ($v === null) return true;
+    if (is_string($v)) return trim($v) === '';
+    return false;
+  }
+
+  /** value transformation filters (trim/lower/upper/join/number/date/etc.) */
+  public static function applyFiltersChain($value, array $filters) {
+    foreach ($filters as $f) {
+      [$name, $arg] = $f + [null, null];
+      switch ($name) {
+        case 'trim':
+          if (is_string($value)) $value = trim($value);
+          break;
+        case 'lower':
+          if (is_string($value)) $value = function_exists('mb_strtolower') ? mb_strtolower($value) : strtolower($value);
+          break;
+        case 'upper':
+          if (is_string($value)) $value = function_exists('mb_strtoupper') ? mb_strtoupper($value) : strtoupper($value);
+          break;
+        case 'title':
+          if (is_string($value)) {
+            $value = function_exists('mb_convert_case') ? mb_convert_case($value, MB_CASE_TITLE, 'UTF-8') : ucwords(strtolower($value));
+          }
+          break;
+        case 'ucfirst':
+          if (is_string($value) && $value !== '') {
+            $first = function_exists('mb_substr') ? mb_substr($value, 0, 1) : substr($value, 0, 1);
+            $rest  = function_exists('mb_substr') ? mb_substr($value, 1)   : substr($value, 1);
+            $value = (function_exists('mb_strtoupper') ? mb_strtoupper($first) : strtoupper($first)) . $rest;
+          }
+          break;
+        case 'strip_tags':
+          if (is_string($value)) $value = strip_tags($value);
+          break;
+        case 'nl2br':
+          if (is_string($value)) $value = nl2br($value);
+          break;
+        case 'escape_attr':
+          if (is_string($value)) $value = esc_attr($value);
+          break;
+        case 'json':
+          $value = wp_json_encode($value);
+          break;
+        case 'length':
+          if (is_array($value)) $value = count($value);
+          else $value = is_string($value) ? (function_exists('mb_strlen') ? mb_strlen($value) : strlen($value)) : 0;
+          break;
+        case 'unique':
+          if (is_array($value)) $value = array_values(array_unique($value));
+          break;
+        case 'join':
+          if (is_array($value)) {
+            $sep = isset($arg) ? (string)$arg : ', ';
+            $value = implode($sep, array_map('strval', $value));
+          }
+          break;
+        case 'number':
+          $dec = is_numeric($arg) ? (int)$arg : 0;
+          if (is_numeric($value)) $value = number_format((float)$value, $dec, '.', ',');
+          break;
+        case 'date':
+          $fmt = ($arg !== null && $arg !== '') ? (string)$arg : 'Y-m-d';
+          $ts  = null;
+          if (is_numeric($value)) {
+            $ts = (int)$value;
+          } elseif (is_string($value) && $value !== '') {
+            $try = strtotime($value);
+            if ($try !== false) $ts = $try;
+          }
+          if ($ts !== null) $value = date_i18n($fmt, $ts);
+          break;
+      }
+    }
+    return $value;
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/context.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/context.php
@@ -1,0 +1,35 @@
+<?php
+namespace Grow\BricksTags\Support;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class Context {
+  private static ?int $hostIdCache = null;
+
+  /** resolve Page 2 (host page / queried object) with caching */
+  public static function resolveHostPageId($post): int {
+    if (self::$hostIdCache !== null) return self::$hostIdCache;
+
+    $host_id = get_queried_object_id();
+    if (!$host_id) {
+      $global_post = get_post();
+      if ($global_post instanceof \WP_Post) $host_id = $global_post->ID;
+    }
+    if (!$host_id && $post instanceof \WP_Post) $host_id = $post->ID;
+    if (!$host_id) $host_id = get_the_ID();
+
+    self::$hostIdCache = (int)$host_id;
+    return self::$hostIdCache;
+  }
+
+  public static function inferTermId(): int {
+    $qo = get_queried_object();
+    if ($qo && isset($qo->term_id)) return (int)$qo->term_id;
+    return 0;
+  }
+
+  public static function inferUserId(): int {
+    $u = wp_get_current_user();
+    return ($u && $u->exists()) ? (int)$u->ID : 0;
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/context.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/context.php
@@ -1,35 +1,99 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags\Support;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class Context {
-  private static ?int $hostIdCache = null;
+/**
+ * Context resolution utilities for determining host page and object IDs
+ */
+final class Context
+{
+    private static ?int $hostIdCache = null;
+    private static ?int $termIdCache = null;
+    private static ?int $userIdCache = null;
 
-  /** resolve Page 2 (host page / queried object) with caching */
-  public static function resolveHostPageId($post): int {
-    if (self::$hostIdCache !== null) return self::$hostIdCache;
+    /**
+     * Resolve the host page ID (queried object) with caching
+     * This is the page where the FAQ is being displayed
+     */
+    public static function resolveHostPageId($post): int
+    {
+        if (self::$hostIdCache !== null) {
+            return self::$hostIdCache;
+        }
 
-    $host_id = get_queried_object_id();
-    if (!$host_id) {
-      $global_post = get_post();
-      if ($global_post instanceof \WP_Post) $host_id = $global_post->ID;
+        // Try to get the queried object ID first
+        $hostId = get_queried_object_id();
+        
+        if (!$hostId) {
+            $globalPost = get_post();
+            if ($globalPost instanceof \WP_Post) {
+                $hostId = $globalPost->ID;
+            }
+        }
+        
+        if (!$hostId && $post instanceof \WP_Post) {
+            $hostId = $post->ID;
+        }
+        
+        if (!$hostId) {
+            $hostId = get_the_ID();
+        }
+
+        self::$hostIdCache = (int) $hostId;
+        return self::$hostIdCache;
     }
-    if (!$host_id && $post instanceof \WP_Post) $host_id = $post->ID;
-    if (!$host_id) $host_id = get_the_ID();
 
-    self::$hostIdCache = (int)$host_id;
-    return self::$hostIdCache;
-  }
+    /**
+     * Get the current term ID with caching
+     */
+    public static function inferTermId(): int
+    {
+        if (self::$termIdCache !== null) {
+            return self::$termIdCache;
+        }
 
-  public static function inferTermId(): int {
-    $qo = get_queried_object();
-    if ($qo && isset($qo->term_id)) return (int)$qo->term_id;
-    return 0;
-  }
+        $queriedObject = get_queried_object();
+        if ($queriedObject && isset($queriedObject->term_id)) {
+            self::$termIdCache = (int) $queriedObject->term_id;
+            return self::$termIdCache;
+        }
 
-  public static function inferUserId(): int {
-    $u = wp_get_current_user();
-    return ($u && $u->exists()) ? (int)$u->ID : 0;
-  }
+        self::$termIdCache = 0;
+        return 0;
+    }
+
+    /**
+     * Get the current user ID with caching
+     */
+    public static function inferUserId(): int
+    {
+        if (self::$userIdCache !== null) {
+            return self::$userIdCache;
+        }
+
+        $user = wp_get_current_user();
+        if ($user && $user->exists()) {
+            self::$userIdCache = (int) $user->ID;
+            return self::$userIdCache;
+        }
+
+        self::$userIdCache = 0;
+        return 0;
+    }
+
+    /**
+     * Clear all caches (useful for testing or when context changes)
+     */
+    public static function clearCache(): void
+    {
+        self::$hostIdCache = null;
+        self::$termIdCache = null;
+        self::$userIdCache = null;
+    }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
@@ -146,7 +146,7 @@ final class Parser
                     $kv['source'] = $value;
                     continue;
                 }
-                if (in_array($key, self::KNOWN_FILTERS, true)) {
+                if (isset(self::KNOWN_FILTERS[$key])) {
                     $filters[] = [$key, $value];
                     continue;
                 }
@@ -154,11 +154,11 @@ final class Parser
                 continue;
             }
 
-            if (in_array($token, self::KNOWN_FILTERS, true)) {
+            if (isset(self::KNOWN_FILTERS[$token])) {
                 $filters[] = [$token, null];
                 continue;
             }
-            if (in_array($token, self::KNOWN_FLAGS, true)) {
+            if (isset(self::KNOWN_FLAGS[$token])) {
                 $flags[] = $token;
                 continue;
             }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
@@ -1,0 +1,143 @@
+<?php
+namespace Grow\BricksTags\Support;
+
+use Grow\BricksTags\Rendering\Finalizer;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class Parser {
+
+  /** Replace all {gt_ctx:...} inside a string with resolved values (host page scope), applying filters/flags/fallbacks. */
+  public static function resolveGtCtxWithinString(string $s, string $context): string {
+    if (strpos($s, '{gt_ctx:') === false) return $s;
+
+    $out = '';
+    $i = 0; $len = strlen($s);
+    // Hard cap to avoid pathological scans
+    if ($len > 100000) { return $s; }
+
+    while ($i < $len) {
+      $start = strpos($s, '{gt_ctx:', $i);
+      if ($start === false) { $out .= substr($s, $i); break; }
+
+      $out .= substr($s, $i, $start - $i);
+      $cursor = $start + strlen('{gt_ctx:');
+
+      // inner part
+      $inner = '';
+      if ($cursor < $len && $s[$cursor] === '{') {
+        $endInner = self::findMatchingBrace($s, $cursor);
+        if ($endInner === -1) { // malformed, copy literally
+          $out .= substr($s, $start, 1);
+          $i = $start + 1;
+          continue;
+        }
+        $inner = substr($s, $cursor, $endInner - $cursor + 1);
+        $cursor = $endInner + 1;
+      } else {
+        $segEnd = $cursor;
+        while ($segEnd < $len && $s[$segEnd] !== '|' && $s[$segEnd] !== '}') $segEnd++;
+        $inner = substr($s, $cursor, $segEnd - $cursor);
+        $cursor = $segEnd;
+      }
+
+      // options until closing '}'
+      $optStart = $cursor;
+      while ($cursor < $len && $s[$cursor] !== '}') $cursor++;
+      if ($cursor >= $len) { $out .= substr($s, $start); $i = $len; break; }
+
+      $optionsStr = substr($s, $optStart, $cursor - $optStart); // may start with '|'
+      $parts = [];
+      if ($optionsStr !== '') {
+        $optionsStr = ltrim($optionsStr, '|');
+        if ($optionsStr !== '') $parts = explode('|', $optionsStr);
+      }
+      $opts = self::parseOptionTokens($parts);
+
+      // Resolve this one {gt_ctx:...}
+      $host_id = Context::resolveHostPageId(get_post());
+      $resolved = $inner;
+      if (function_exists('bricks_render_dynamic_data')) {
+        $resolved = bricks_render_dynamic_data($inner, $host_id, $context);
+      }
+      if (Finalizer::isEffectivelyEmpty($resolved) && $opts['fallback'] !== null) {
+        $resolved = $opts['fallback'];
+      }
+      $resolved = Finalizer::applyFiltersChain($resolved, $opts['filters']);
+      $resolved = Finalizer::finalizeOutput($resolved, $opts['flags'] ?? [], $context);
+
+      $out .= $resolved;
+      $i = $cursor + 1; // past '}'
+    }
+    return $out;
+  }
+
+  /** Parse a full {gt_ctx:...} tag's arg string into [inner, options] */
+  public static function parseGtCtxTag(string $argStr): array {
+    $argStr = (string)$argStr;
+    $inner = ''; $rest = '';
+
+    if ($argStr !== '' && $argStr[0] === '{') {
+      $pos = self::findMatchingBrace($argStr, 0);
+      if ($pos !== -1) { $inner = substr($argStr, 0, $pos + 1); $rest = substr($argStr, $pos + 1); }
+    } else {
+      $cut = strpos($argStr, '|');
+      if ($cut === false) { $inner = $argStr; $rest = ''; }
+      else { $inner = substr($argStr, 0, $cut); $rest = substr($argStr, $cut); }
+    }
+
+    $parts = [];
+    if ($rest !== '') {
+      $rest = ltrim($rest, '|');
+      if ($rest !== '') $parts = explode('|', $rest);
+    }
+    $opts = self::parseOptionTokens($parts);
+    return [$inner, $opts];
+  }
+
+  /** Token parser for flags/kv/filters/fallback */
+  public static function parseOptionTokens(array $tokens): array {
+    $flags = []; $kv = []; $filters = []; $fallback = null;
+
+    $known = ['trim','lower','upper','title','ucfirst','strip_tags','nl2br','escape_attr','json','length','unique','join','number','date'];
+    foreach ($tokens as $tok) {
+      $tok = trim($tok); if ($tok === '') continue;
+
+      if (strpos($tok, ':') !== false || strpos($tok, '=') !== false) {
+        $sep = (strpos($tok, ':') !== false) ? ':' : '=';
+        [$k, $v] = array_map('trim', explode($sep, $tok, 2));
+        if ($k === 'default') { $fallback = $v; continue; }
+        if ($k === 'id')      { $kv['id'] = $v; continue; }
+        if ($k === 'source')  { $kv['source'] = $v; continue; }
+        if (in_array($k, $known, true)) { $filters[] = [$k, $v]; continue; }
+        $kv[$k] = $v; continue;
+      }
+
+      if (in_array($tok, $known, true)) { $filters[] = [$tok, null]; continue; }
+      if (in_array($tok, ['raw','noescape'], true)) { $flags[] = $tok; continue; }
+
+      if ($fallback === null) { $fallback = $tok; continue; }
+    }
+
+    return [
+      'flags'    => $flags,
+      'kv'       => $kv,
+      'filters'  => $filters,
+      'fallback' => $fallback,
+    ];
+  }
+
+  /** Find matching '}' for a '{' starting at $start (single-nesting aware) */
+  public static function findMatchingBrace(string $s, int $start): int {
+    if (!isset($s[$start]) || $s[$start] !== '{') return -1;
+    $depth = 0; $len = strlen($s);
+    for ($i = $start; $i < $len; $i++) {
+      if ($s[$i] === '{') { $depth++; }
+      elseif ($s[$i] === '}') {
+        $depth--;
+        if ($depth === 0) return $i;
+      }
+    }
+    return -1;
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/support/parser.php
@@ -1,143 +1,276 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags\Support;
 
 use Grow\BricksTags\Rendering\Finalizer;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class Parser {
-
-  /** Replace all {gt_ctx:...} inside a string with resolved values (host page scope), applying filters/flags/fallbacks. */
-  public static function resolveGtCtxWithinString(string $s, string $context): string {
-    if (strpos($s, '{gt_ctx:') === false) return $s;
-
-    $out = '';
-    $i = 0; $len = strlen($s);
-    // Hard cap to avoid pathological scans
-    if ($len > 100000) { return $s; }
-
-    while ($i < $len) {
-      $start = strpos($s, '{gt_ctx:', $i);
-      if ($start === false) { $out .= substr($s, $i); break; }
-
-      $out .= substr($s, $i, $start - $i);
-      $cursor = $start + strlen('{gt_ctx:');
-
-      // inner part
-      $inner = '';
-      if ($cursor < $len && $s[$cursor] === '{') {
-        $endInner = self::findMatchingBrace($s, $cursor);
-        if ($endInner === -1) { // malformed, copy literally
-          $out .= substr($s, $start, 1);
-          $i = $start + 1;
-          continue;
-        }
-        $inner = substr($s, $cursor, $endInner - $cursor + 1);
-        $cursor = $endInner + 1;
-      } else {
-        $segEnd = $cursor;
-        while ($segEnd < $len && $s[$segEnd] !== '|' && $s[$segEnd] !== '}') $segEnd++;
-        $inner = substr($s, $cursor, $segEnd - $cursor);
-        $cursor = $segEnd;
-      }
-
-      // options until closing '}'
-      $optStart = $cursor;
-      while ($cursor < $len && $s[$cursor] !== '}') $cursor++;
-      if ($cursor >= $len) { $out .= substr($s, $start); $i = $len; break; }
-
-      $optionsStr = substr($s, $optStart, $cursor - $optStart); // may start with '|'
-      $parts = [];
-      if ($optionsStr !== '') {
-        $optionsStr = ltrim($optionsStr, '|');
-        if ($optionsStr !== '') $parts = explode('|', $optionsStr);
-      }
-      $opts = self::parseOptionTokens($parts);
-
-      // Resolve this one {gt_ctx:...}
-      $host_id = Context::resolveHostPageId(get_post());
-      $resolved = $inner;
-      if (function_exists('bricks_render_dynamic_data')) {
-        $resolved = bricks_render_dynamic_data($inner, $host_id, $context);
-      }
-      if (Finalizer::isEffectivelyEmpty($resolved) && $opts['fallback'] !== null) {
-        $resolved = $opts['fallback'];
-      }
-      $resolved = Finalizer::applyFiltersChain($resolved, $opts['filters']);
-      $resolved = Finalizer::finalizeOutput($resolved, $opts['flags'] ?? [], $context);
-
-      $out .= $resolved;
-      $i = $cursor + 1; // past '}'
-    }
-    return $out;
-  }
-
-  /** Parse a full {gt_ctx:...} tag's arg string into [inner, options] */
-  public static function parseGtCtxTag(string $argStr): array {
-    $argStr = (string)$argStr;
-    $inner = ''; $rest = '';
-
-    if ($argStr !== '' && $argStr[0] === '{') {
-      $pos = self::findMatchingBrace($argStr, 0);
-      if ($pos !== -1) { $inner = substr($argStr, 0, $pos + 1); $rest = substr($argStr, $pos + 1); }
-    } else {
-      $cut = strpos($argStr, '|');
-      if ($cut === false) { $inner = $argStr; $rest = ''; }
-      else { $inner = substr($argStr, 0, $cut); $rest = substr($argStr, $cut); }
-    }
-
-    $parts = [];
-    if ($rest !== '') {
-      $rest = ltrim($rest, '|');
-      if ($rest !== '') $parts = explode('|', $rest);
-    }
-    $opts = self::parseOptionTokens($parts);
-    return [$inner, $opts];
-  }
-
-  /** Token parser for flags/kv/filters/fallback */
-  public static function parseOptionTokens(array $tokens): array {
-    $flags = []; $kv = []; $filters = []; $fallback = null;
-
-    $known = ['trim','lower','upper','title','ucfirst','strip_tags','nl2br','escape_attr','json','length','unique','join','number','date'];
-    foreach ($tokens as $tok) {
-      $tok = trim($tok); if ($tok === '') continue;
-
-      if (strpos($tok, ':') !== false || strpos($tok, '=') !== false) {
-        $sep = (strpos($tok, ':') !== false) ? ':' : '=';
-        [$k, $v] = array_map('trim', explode($sep, $tok, 2));
-        if ($k === 'default') { $fallback = $v; continue; }
-        if ($k === 'id')      { $kv['id'] = $v; continue; }
-        if ($k === 'source')  { $kv['source'] = $v; continue; }
-        if (in_array($k, $known, true)) { $filters[] = [$k, $v]; continue; }
-        $kv[$k] = $v; continue;
-      }
-
-      if (in_array($tok, $known, true)) { $filters[] = [$tok, null]; continue; }
-      if (in_array($tok, ['raw','noescape'], true)) { $flags[] = $tok; continue; }
-
-      if ($fallback === null) { $fallback = $tok; continue; }
-    }
-
-    return [
-      'flags'    => $flags,
-      'kv'       => $kv,
-      'filters'  => $filters,
-      'fallback' => $fallback,
+/**
+ * Parser utilities for dynamic tag processing
+ * 
+ * Handles parsing of tag arguments, options, and nested tag resolution
+ * with optimized performance for large content blocks.
+ */
+final class Parser
+{
+    // Performance optimization: cache known filter names
+    private const KNOWN_FILTERS = [
+        'trim', 'lower', 'upper', 'title', 'ucfirst', 'strip_tags', 'nl2br',
+        'escape_attr', 'json', 'length', 'unique', 'join', 'number', 'date'
     ];
-  }
 
-  /** Find matching '}' for a '{' starting at $start (single-nesting aware) */
-  public static function findMatchingBrace(string $s, int $start): int {
-    if (!isset($s[$start]) || $s[$start] !== '{') return -1;
-    $depth = 0; $len = strlen($s);
-    for ($i = $start; $i < $len; $i++) {
-      if ($s[$i] === '{') { $depth++; }
-      elseif ($s[$i] === '}') {
-        $depth--;
-        if ($depth === 0) return $i;
-      }
+    private const KNOWN_FLAGS = ['raw', 'noescape'];
+
+    /**
+     * Replace all {gt_ctx:...} tags inside a string with resolved values
+     * 
+     * @param string $content The content to process
+     * @param string $context The rendering context
+     * @return string The processed content
+     */
+    public static function resolveGtCtxWithinString(string $content, string $context): string
+    {
+        if (strpos($content, '{gt_ctx:') === false) {
+            return $content;
+        }
+
+        // Hard cap to avoid pathological scans
+        if (strlen($content) > 100000) {
+            return $content;
+        }
+
+        $output = '';
+        $position = 0;
+        $length = strlen($content);
+
+        while ($position < $length) {
+            $start = strpos($content, '{gt_ctx:', $position);
+            if ($start === false) {
+                $output .= substr($content, $position);
+                break;
+            }
+
+            // Add content before the tag
+            $output .= substr($content, $position, $start - $position);
+            $cursor = $start + strlen('{gt_ctx:');
+
+            // Parse inner content
+            $inner = self::parseInnerContent($content, $cursor, $length);
+            $cursor += strlen($inner);
+
+            // Parse options
+            $options = self::parseOptions($content, $cursor, $length);
+            $cursor = $options['cursor'];
+
+            // Resolve the tag
+            $resolved = self::resolveGtCtxTag($inner, $context, $options['parsed']);
+
+            $output .= $resolved;
+            $position = $cursor + 1; // past '}'
+        }
+
+        return $output;
     }
-    return -1;
-  }
+
+    /**
+     * Parse a full {gt_ctx:...} tag's argument string
+     */
+    public static function parseGtCtxTag(string $argStr): array
+    {
+        $inner = '';
+        $rest = '';
+
+        if ($argStr !== '' && $argStr[0] === '{') {
+            $pos = self::findMatchingBrace($argStr, 0);
+            if ($pos !== -1) {
+                $inner = substr($argStr, 0, $pos + 1);
+                $rest = substr($argStr, $pos + 1);
+            }
+        } else {
+            $cut = strpos($argStr, '|');
+            if ($cut === false) {
+                $inner = $argStr;
+                $rest = '';
+            } else {
+                $inner = substr($argStr, 0, $cut);
+                $rest = substr($argStr, $cut);
+            }
+        }
+
+        $parts = [];
+        if ($rest !== '') {
+            $rest = ltrim($rest, '|');
+            if ($rest !== '') {
+                $parts = explode('|', $rest);
+            }
+        }
+
+        $opts = self::parseOptionTokens($parts);
+        return [$inner, $opts];
+    }
+
+    /**
+     * Parse option tokens into structured data
+     */
+    public static function parseOptionTokens(array $tokens): array
+    {
+        $flags = [];
+        $kv = [];
+        $filters = [];
+        $fallback = null;
+
+        foreach ($tokens as $token) {
+            $token = trim($token);
+            if ($token === '') {
+                continue;
+            }
+
+            if (strpos($token, ':') !== false || strpos($token, '=') !== false) {
+                $sep = (strpos($token, ':') !== false) ? ':' : '=';
+                [$key, $value] = array_map('trim', explode($sep, $token, 2));
+                
+                if ($key === 'default') {
+                    $fallback = $value;
+                    continue;
+                }
+                if ($key === 'id') {
+                    $kv['id'] = $value;
+                    continue;
+                }
+                if ($key === 'source') {
+                    $kv['source'] = $value;
+                    continue;
+                }
+                if (in_array($key, self::KNOWN_FILTERS, true)) {
+                    $filters[] = [$key, $value];
+                    continue;
+                }
+                $kv[$key] = $value;
+                continue;
+            }
+
+            if (in_array($token, self::KNOWN_FILTERS, true)) {
+                $filters[] = [$token, null];
+                continue;
+            }
+            if (in_array($token, self::KNOWN_FLAGS, true)) {
+                $flags[] = $token;
+                continue;
+            }
+
+            if ($fallback === null) {
+                $fallback = $token;
+                continue;
+            }
+        }
+
+        return [
+            'flags' => $flags,
+            'kv' => $kv,
+            'filters' => $filters,
+            'fallback' => $fallback,
+        ];
+    }
+
+    /**
+     * Find matching closing brace for an opening brace
+     */
+    public static function findMatchingBrace(string $content, int $start): int
+    {
+        if (!isset($content[$start]) || $content[$start] !== '{') {
+            return -1;
+        }
+
+        $depth = 0;
+        $length = strlen($content);
+
+        for ($i = $start; $i < $length; $i++) {
+            if ($content[$i] === '{') {
+                $depth++;
+            } elseif ($content[$i] === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Parse inner content of a gt_ctx tag
+     */
+    private static function parseInnerContent(string $content, int $cursor, int $length): string
+    {
+        if ($cursor >= $length) {
+            return '';
+        }
+
+        if ($content[$cursor] === '{') {
+            $endInner = self::findMatchingBrace($content, $cursor);
+            if ($endInner === -1) {
+                return '';
+            }
+            return substr($content, $cursor, $endInner - $cursor + 1);
+        }
+
+        $segEnd = $cursor;
+        while ($segEnd < $length && $content[$segEnd] !== '|' && $content[$segEnd] !== '}') {
+            $segEnd++;
+        }
+
+        return substr($content, $cursor, $segEnd - $cursor);
+    }
+
+    /**
+     * Parse options section of a gt_ctx tag
+     */
+    private static function parseOptions(string $content, int $cursor, int $length): array
+    {
+        $optStart = $cursor;
+        while ($cursor < $length && $content[$cursor] !== '}') {
+            $cursor++;
+        }
+
+        $optionsStr = substr($content, $optStart, $cursor - $optStart);
+        $parts = [];
+
+        if ($optionsStr !== '') {
+            $optionsStr = ltrim($optionsStr, '|');
+            if ($optionsStr !== '') {
+                $parts = explode('|', $optionsStr);
+            }
+        }
+
+        return [
+            'cursor' => $cursor,
+            'parsed' => self::parseOptionTokens($parts)
+        ];
+    }
+
+    /**
+     * Resolve a single gt_ctx tag
+     */
+    private static function resolveGtCtxTag(string $inner, string $context, array $opts): string
+    {
+        $hostId = Context::resolveHostPageId(get_post());
+        $resolved = $inner;
+
+        if (function_exists('bricks_render_dynamic_data')) {
+            $resolved = bricks_render_dynamic_data($inner, $hostId, $context);
+        }
+
+        if (Finalizer::isEffectivelyEmpty($resolved) && $opts['fallback'] !== null) {
+            $resolved = $opts['fallback'];
+        }
+
+        $resolved = Finalizer::applyFiltersChain($resolved, $opts['filters']);
+        return Finalizer::finalizeOutput($resolved, $opts['flags'] ?? [], $context);
+    }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-ctx-tag.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-ctx-tag.php
@@ -1,33 +1,61 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Grow\BricksTags\Tags;
 
 use Grow\BricksTags\Rendering\Finalizer;
 use Grow\BricksTags\Support\Context;
 use Grow\BricksTags\Support\Parser;
 
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-final class GtCtxTag {
-  /**
-   * {gt_ctx:{...}[|DEFAULT][|filters]}
-   * Resolve the inner string in host-page (queried object) context.
-   */
-  public static function render(string $argStr, $post, string $context) {
-    // Parse inner + options (supports inner literal or inner {...})
-    [$inner, $opts] = Parser::parseGtCtxTag($argStr);
+/**
+ * GT Context Tag Handler
+ * 
+ * Resolves content in host page context, perfect for FAQs that need to reference
+ * the current page's data (e.g., payor name, location, etc.)
+ * 
+ * Usage: {gt_ctx:{payor_name}|Default Payor|title}
+ * 
+ * This allows you to have one FAQ template that dynamically populates
+ * context-specific information from the page where it's displayed.
+ */
+final class GtCtxTag
+{
+    /**
+     * Render the context tag
+     * 
+     * @param string $argStr The tag arguments (e.g., "{payor_name}|Default|title")
+     * @param mixed $post The current post object
+     * @param string $context The rendering context (text, image, etc.)
+     * @return string The resolved content
+     */
+    public static function render(string $argStr, $post, string $context): string
+    {
+        // Parse inner content and options
+        [$inner, $opts] = Parser::parseGtCtxTag($argStr);
 
-    $host_id = Context::resolveHostPageId($post);
-    $value   = $inner;
+        // Get the host page ID (the page where this FAQ is being displayed)
+        $hostId = Context::resolveHostPageId($post);
+        
+        // Start with the inner content
+        $value = $inner;
 
-    if (function_exists('bricks_render_dynamic_data')) {
-      $value = bricks_render_dynamic_data($inner, $host_id, $context);
+        // Resolve any dynamic data in the inner content using Bricks
+        if (function_exists('bricks_render_dynamic_data')) {
+            $value = bricks_render_dynamic_data($inner, $hostId, $context);
+        }
+
+        // Apply fallback if the resolved value is empty
+        if (Finalizer::isEffectivelyEmpty($value) && $opts['fallback'] !== null) {
+            $value = $opts['fallback'];
+        }
+
+        // Apply any filters and finalize the output
+        $value = Finalizer::applyFiltersChain($value, $opts['filters']);
+        return Finalizer::finalizeOutput($value, $opts['flags'] ?? [], $context);
     }
-
-    if (Finalizer::isEffectivelyEmpty($value) && $opts['fallback'] !== null) {
-      $value = $opts['fallback'];
-    }
-
-    $value = Finalizer::applyFiltersChain($value, $opts['filters']);
-    return Finalizer::finalizeOutput($value, $opts['flags'] ?? [], $context);
-  }
 }

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-ctx-tag.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-ctx-tag.php
@@ -1,0 +1,33 @@
+<?php
+namespace Grow\BricksTags\Tags;
+
+use Grow\BricksTags\Rendering\Finalizer;
+use Grow\BricksTags\Support\Context;
+use Grow\BricksTags\Support\Parser;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class GtCtxTag {
+  /**
+   * {gt_ctx:{...}[|DEFAULT][|filters]}
+   * Resolve the inner string in host-page (queried object) context.
+   */
+  public static function render(string $argStr, $post, string $context) {
+    // Parse inner + options (supports inner literal or inner {...})
+    [$inner, $opts] = Parser::parseGtCtxTag($argStr);
+
+    $host_id = Context::resolveHostPageId($post);
+    $value   = $inner;
+
+    if (function_exists('bricks_render_dynamic_data')) {
+      $value = bricks_render_dynamic_data($inner, $host_id, $context);
+    }
+
+    if (Finalizer::isEffectivelyEmpty($value) && $opts['fallback'] !== null) {
+      $value = $opts['fallback'];
+    }
+
+    $value = Finalizer::applyFiltersChain($value, $opts['filters']);
+    return Finalizer::finalizeOutput($value, $opts['flags'] ?? [], $context);
+  }
+}

--- a/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-field-tag.php
+++ b/wp-content/plugins/grow-dynamic-tags-for-bricks/src/tags/gt-field-tag.php
@@ -1,0 +1,58 @@
+<?php
+namespace Grow\BricksTags\Tags;
+
+use Grow\BricksTags\Rendering\Finalizer;
+use Grow\BricksTags\Support\Context;
+use Grow\BricksTags\Support\Parser;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class GtFieldTag {
+  /**
+   * {gt_field:meta_key[|source:post|term|user][|id:<ID>][|raw][|noescape][|DEFAULT][|filters]}
+   */
+  public static function render(string $argStr, $post, string $context) {
+    $parts = explode('|', (string)$argStr);
+    $meta_key = trim(array_shift($parts));
+    if ($meta_key === '') return '';
+
+    $opts   = Parser::parseOptionTokens($parts); // flags, kv, filters, fallback
+    $source = isset($opts['kv']['source']) ? strtolower($opts['kv']['source']) : 'post';
+    $id     = isset($opts['kv']['id']) ? (int)$opts['kv']['id'] : 0;
+
+    $value = '';
+
+    if ($source === 'post') {
+      $post_id = $id ?: ( $post instanceof \WP_Post ? $post->ID : get_the_ID() );
+      if ($post_id) $value = get_post_meta($post_id, $meta_key, true);
+    } elseif ($source === 'term') {
+      $term_id = $id ?: Context::inferTermId();
+      if ($term_id) $value = get_term_meta($term_id, $meta_key, true);
+    } elseif ($source === 'user') {
+      $user_id = $id ?: Context::inferUserId();
+      if ($user_id) $value = get_user_meta($user_id, $meta_key, true);
+    }
+
+    // Pre-resolve any {gt_ctx:...} INSIDE the fetched string BEFORE other tags
+    if (is_string($value) && $value !== '') {
+      $value = Parser::resolveGtCtxWithinString($value, $context);
+    }
+
+    // Then let Bricks render remaining tags in LOOP ITEM context (only if braces remain)
+    if (is_string($value) && $value !== '' && strpos($value, '{') !== false && function_exists('bricks_render_dynamic_data')) {
+      $loop_post_id = ($source === 'post')
+        ? ($id ?: ( $post instanceof \WP_Post ? $post->ID : get_the_ID() ))
+        : ( $post instanceof \WP_Post ? $post->ID : get_the_ID() );
+      $value = bricks_render_dynamic_data($value, $loop_post_id, $context);
+    }
+
+    // Fallback if empty
+    if (Finalizer::isEffectivelyEmpty($value) && $opts['fallback'] !== null) {
+      $value = $opts['fallback'];
+    }
+
+    // Apply formatters & finalize
+    $value = Finalizer::applyFiltersChain($value, $opts['filters']);
+    return Finalizer::finalizeOutput($value, $opts['flags'], $context);
+  }
+}


### PR DESCRIPTION
You can track your time for reviewing here: https://app.clickup.com/t/30963010/GT-1428

# Fixes, Changes, Additions, Removals (What)
Kyle built this plugin to solve a common content management headache. We have a custom post type for FAQs that gets used across multiple pages, but each page needs slightly different content - usually just the insurance provider name swapped out. "Therapy supported by United Healthcare..." vs "Therapy supported by Aetna..." vs "Therapy supported by Blue Cross Blue Shield...". Instead of maintaining 10+ duplicate FAQs with minor differences, this plugin lets us create one FAQ template that automatically pulls in the right insurance name based on which page it's displayed on.

TL;DR: One FAQ template, automatically customized for each page. No more copy-pasting and forgetting to update one of the duplicates.